### PR TITLE
Added SerialGC (#56)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ add_library(hardware_library OBJECT
         src/SerialUserInterface.h
         src/CombinedUserInterface.h
         src/CombinedUserInterface.cpp
-)
+        src/SerialGC.h
+        src/SerialGC.cpp
+        )
 
 add_library(core_library OBJECT
 
@@ -68,6 +70,8 @@ add_library(core_library OBJECT
         src/vlcbdefs.hpp
         src/ConsumeOwnEventsService.h
         src/ConsumeOwnEventsService.cpp
+        src/GridConnect.cpp
+        src/GridConnect.h
 )
 
 target_link_libraries(core_library PUBLIC)
@@ -108,4 +112,5 @@ add_executable(testAll
         test/testEventTeachingService.cpp
         test/testConsumeOwnEventsService.cpp
         test/testLongMessageService.cpp
+        test/testGridConnect.cpp
 )

--- a/src/GridConnect.cpp
+++ b/src/GridConnect.cpp
@@ -1,0 +1,241 @@
+// Copyright (C) David Ellis
+// This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+// Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+// The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+
+//
+// Functions to convert between GridConnect format messages and CANMessage objects
+//
+
+
+// the GridConnect message syntax for a normal message
+// : <S | X> <IDENTIFIER> <N> <DATA-0> <DATA-1> … <DATA-7> ;
+// where:
+//     ':' and ';' are message start and end characters respectively
+//     Identifier and data fields are treated as base-16 digits (hexadecimal).
+//     'S' & 'X' characters indicates standard or extended CAN frames
+//     'N' character indicates a normal (not RTR) message
+
+// the GridConnect message syntax for a 'Request to Transmit' (RTR) message (there is no data field)
+// : <S | X> <IDENTIFIER> <R> <LENGTH>;
+// where:
+//     ':' and ';' are message start and end characters respectively
+//     Identifier field is treated as base-16 digits (hexadecimal).
+//     'S' & 'X' characters indicates standard or extended CAN frames
+//     'R' character indicates an RTR message
+//     Length field is a single ASCII decimal character from ‘0’ to ‘8’ that specifies the length
+//     of the message
+
+// the difference in the GridConnect version used here is in the format of the Identifier field:
+//
+// For a standard can message with an 11 bit identifier, the GridConnect identifier field is 4 hex characters,
+// i.e. 16 bits
+// The CBUS implementation shifts the 11 bit ID by 5, i.e. fills the top bit, with the lower 5 bits being 0
+// (This was done to map directly onto SIDH and SIDL registers in the PIC processor family)
+// And the GridConnect Identifier field is also leading zero padded, so always 4 characters for a standard message
+// 
+// For an extended can message with an 29 bit identifier, the GridConnect identifier field is 8 hex characters,
+// i.e. 32 bits
+// In this case the mapping is a bit more complex
+// IDENTIFIER[0,1] - bits [28:21] of the can identifier
+// IDENTIFIER[2] - bits [20:18] of the can identifier, left shifted by 1, bottom bit set to zero
+// IDENTIFIER[3] - bits [17:16] of the can identifier, bottom two bits, top two bits set to 0
+// IDENTIFIER[4,5,6,7] - bits [15:0] of the can identifier
+// (This maps directly onto SIDH, SIDL, EIDH and EIDL registers the PIC processor family)
+// And the GridConnect Identifier field is also leading zero padded, so always 8 characters for an extended message
+// 
+
+#include <ctype.h>
+#include "GridConnect.h"
+
+namespace VLCB
+{
+
+  bool encodeGridConnect(char * gcBuffer, CANMessage *msg){
+      byte offset = 0;
+      gcBuffer[0] = 0;  // null terminate buffer to start with
+      // set starting character & standard or extended CAN identifier
+      if (msg->ext) {
+        if (msg->id > 0x1FFFFFFF)
+        {
+          // id is greater than 29 bits, so fail the encoding
+          return false;
+        }
+        // mark as extended message
+        strcpy (gcBuffer,":X");
+        // extended 29 bit CAN idenfier in bytes 2 to 9
+        // chars 2 & 3 are ID bits 21 to 28
+        sprintf(gcBuffer + 2, "%02X", (msg->id) >> 21);
+        // char 4 -  bits 1 to 3 are ID bits 18 to 20
+        sprintf(gcBuffer + 4, "%01X", ((msg->id) >> 17) & 0xE);
+        // char 5 -  bits 0 to 1 are ID bits 16 & 17
+        sprintf(gcBuffer + 5, "%01X", ((msg->id) >> 16) & 0x3);
+        // chars 6 to 9 are ID bits 0 to 15
+        sprintf(gcBuffer + 6, "%04X", msg->id & 0xFFFF);
+        offset = 10;
+      } else {// mark sas standard message
+        if (msg->id > 0x7FF)
+        {
+          // id is greater than 11 bits, so fail the encoding
+          return false;
+        }
+        strcpy (gcBuffer,":S");
+        // standard 11 bit CAN idenfier in bytes 2 to 5, left shifted 5 to occupy highest bits
+        sprintf(gcBuffer + 2, "%04X", msg->id << 5);
+        offset = 6;
+      }
+      // set RTR or normal - byte 6 or 10
+      strcpy(gcBuffer + offset++, msg->rtr ? "R" : "N");
+      if (msg->len > 8){  // if greater than 8 then faulty msg
+        gcBuffer[0] = 0;
+        return false;
+      }
+      //now add hex data from byte 7 if len > 0
+      for (int i=0; i<msg->len; i++){
+        sprintf(gcBuffer + offset, "%02X", msg->data[i]);
+        offset += 2;
+      }
+      // add terminator
+      strcpy (gcBuffer + offset,";");
+      return true;
+  }
+
+  // Function to convert a pair of hexadecimal characters to a byte value
+  //
+  int ascii_pair_to_byte(const char *pair)
+  {
+      unsigned char* data = (unsigned char*)pair;
+      int result;
+      if (data[1] < 'A') { result = data[1] - '0'; }
+      else { result = data[1] - 'A' + 10; }
+      if (data[0] < 'A') { result += (data[0] - '0') << 4; }
+      else { result += (data[0] - 'A' + 10) << 4; }
+      return result;
+  }
+
+
+  // check supplied array is comprised of only hexadecimal characters
+  //
+  bool checkHexChars(const char *charBuff, int count)
+  {
+    for (int i = 0 ; i< count; i++)
+    {
+      // must be upper case, so fail if lower case
+      if (islower(charBuff[i])){
+        return false;
+      }
+      if (!isxdigit(charBuff[i]))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+  // convert a gridconnect message to CANMessage object
+  // see Gridconnect format at beginning of file for byte positions
+  //
+  bool decodeGridConnect(const char * gcBuffer, CANMessage *message) 
+  {
+    int gcIndex = 0;                          // index used to 'walk' gc message
+    int gcBufferLength = strlen(gcBuffer);    // save for later use
+
+    // must have start of message character
+    if (gcBuffer[gcIndex++] != ':') 
+    {
+      return false;
+    }
+    //
+    // do CAN Identifier, must be either 'X' or 'S'
+    if (gcBuffer[gcIndex] == 'X') 
+    {
+      message->ext = true;
+      // now get 29 bit ID - convert from hex, but check they are all hex first
+      if (checkHexChars(&gcBuffer[2], 8) == false)
+      {
+        return false;
+      }
+      // ok, all hex, so build up id from characters 2 to 9
+      // chars 2 & 3 are bits 21 to 28
+      message->id = uint32_t(ascii_pair_to_byte(&gcBuffer[2])) << 21;
+      // chars 4 & 5 -  bits 5 to 7 are bits 18 to 20
+      message->id += uint32_t(ascii_pair_to_byte(&gcBuffer[4]) & 0xE0) << 13;
+      // chars 4 & 5 -  bits 0 to 1 are bits 16 & 17
+      message->id += uint32_t(ascii_pair_to_byte(&gcBuffer[4]) & 0x3) << 16;
+      // chars 6 & 7 are bits 8 to 15
+      message->id += uint32_t(ascii_pair_to_byte(&gcBuffer[6])) << 8;
+      // chars 8 & 9 are bits 0 to 7 
+      message->id += ascii_pair_to_byte(&gcBuffer[8]);
+      gcIndex = 10;
+    }
+    else if (gcBuffer[gcIndex] == 'S') 
+    {
+      message->ext = false;
+      // now get 11 bit ID - convert from hex, but check they are all hex first
+      if (checkHexChars(&gcBuffer[2], 4) == false)
+      {
+        return false;
+      }
+      // 11 bit identifier needs to be shifted right by 5
+      message->id = strtol(&gcBuffer[2], NULL, 16) >> 5;
+      gcIndex = 6;
+    } 
+    else 
+    {
+      return false;
+    }
+    //
+    // do RTR flag
+    if (gcBuffer[gcIndex] == 'R') 
+    {
+      message->rtr = true;
+    } 
+    else if (gcBuffer[gcIndex] == 'N')
+    {
+      message->rtr = false;
+    } 
+    else 
+    {
+      return false;
+    }
+    gcIndex++;  // set to next character afert RTR flag
+    //
+    // Do data segment - convert hex array to byte array
+    // find out how many chars in data segment (0 to 16, in multiples of 2) 
+    // should be gcBufferLength minus gcIndex as it is now (after RTR flag), minus 1
+    int dataLength = gcBufferLength - gcIndex - 1;
+    // must be even number of hex characters, and no more than 16
+    if ((dataLength % 2 ) || (dataLength > 16 )) 
+    {
+      return false;
+    } 
+    // set length of data segment
+    message->len = dataLength/2;
+    // now convert hex data into bytes
+    for (int i = 0; i < dataLength/2; i++) 
+    {
+      // check they are hex chars first
+      if (checkHexChars(&gcBuffer[gcIndex], 2) == false)
+      {
+        return false;
+      }
+      message->data[i] = ascii_pair_to_byte(&gcBuffer[gcIndex]);
+      gcIndex += 2;
+    }
+    //
+    // must have end of message character
+    if (gcBuffer[gcBufferLength-1] != ';') 
+    {
+      return false;
+    }
+    //
+    return true; 
+  }
+
+
+
+
+
+}

--- a/src/GridConnect.h
+++ b/src/GridConnect.h
@@ -1,0 +1,13 @@
+
+#pragma once
+
+// header files
+#include <Arduino.h>
+#include <Controller.h>
+#include <CanTransport.h>
+
+namespace VLCB
+{
+  bool decodeGridConnect(const char * gcBuffer, CANMessage *message);
+  bool encodeGridConnect(char * txBuffer, CANMessage *msg);
+}

--- a/src/SerialGC.cpp
+++ b/src/SerialGC.cpp
@@ -1,0 +1,123 @@
+// Copyright (C) David Ellis
+// This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+// Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+// The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+#include "SerialGC.h"
+// 3rd party libraries
+#include <Streaming.h>
+#include <string.h>
+#include <ctype.h>
+
+//
+// Class to transfer CAN frames using the GridConnect protocol over the serial port
+//
+// see GridConnect.cpp for more details on this protocol
+
+namespace VLCB
+{
+
+  bool SerialGC::begin()  
+  {
+    Serial << F("> ** GridConnect over serial ** ") << endl;
+    receivedCount = 0;
+    transmitCount = 0;
+    return true;
+  }
+
+
+  //
+  // parse incoming characters & assemble message
+  // return true if valid message assembled & ready
+  //
+  bool SerialGC::available()
+  {
+    bool result = false;
+    static int rxIndex = 0;
+    if (Serial.available())
+    {     
+      char c = Serial.read();
+      c = toupper(c);
+      //
+      // if 'start of message' already seen, save the character, and check for 'end of message'
+      if (rxIndex > 0) 
+      {
+        rxBuffer[rxIndex++] = c;
+        // check if end of buffer reached, and restart if so
+        if (rxIndex >= RXBUFFERSIZE) 
+        {
+          rxIndex = 0;
+        }
+        //
+        // check for 'end of message'
+        if (c == ';')
+        {
+          rxBuffer[rxIndex++] = '\0';     // null terminate
+          rxIndex = 0;
+          result = true;
+        }
+      }
+      //
+      // always check for 'start of message'
+      if (c == ':') 
+      {
+        rxIndex = 0;                    // restart at beginning of buffer
+        rxBuffer[rxIndex++] = c;
+      }
+    }
+    //
+    if (result) 
+    {
+      // We have received a message between a ':' and a ';', so increment count
+      receivedCount++;
+      result = decodeGridConnect(rxBuffer, &rxCANMessage);
+      if (result == false)
+      {
+        // must have been an error in the message, so increment error counter
+        receiveErrorCount++;
+      }
+    }
+    return result;
+  }
+
+
+  //
+  /// get the available CANMessage
+  /// must call available first to ensure there is something to get
+  //
+  CANMessage SerialGC::getNextCanMessage()
+  {
+    return rxCANMessage;
+  }
+
+
+  //
+  /// send a CANMessage message in GridConnect format
+  // see Gridconnect format at beginning of file for byte positions
+  //
+  bool SerialGC::sendCanMessage(CANMessage *msg)
+  {
+    transmitCount++;
+    bool result = encodeGridConnect(txBuffer, msg);
+    if (result)
+    {
+      // output the message
+      Serial.print(txBuffer);
+    }
+    else
+    {
+      transmitErrorCount++;
+    }
+   return result;
+  }
+
+
+  //
+  /// reset
+  //
+  void SerialGC::reset()
+  {
+  }
+
+
+}

--- a/src/SerialGC.h
+++ b/src/SerialGC.h
@@ -1,0 +1,60 @@
+// Copyright (C) David Ellis
+// This file is part of VLCB-Arduino project on https://github.com/SvenRosvall/VLCB-Arduino
+// Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+// The full licence can be found at: http://creativecommons.org/licenses/by-nc-sa/4.0/
+
+#pragma once
+
+// header files
+#include <Arduino.h>
+#include <Controller.h>
+#include <CanTransport.h>
+#include <GridConnect.h>
+
+namespace VLCB
+{
+
+  // constants
+
+  // grid connect should be 28 characters maximum
+  static const int RXBUFFERSIZE = 30;
+
+  //
+  /// an implementation of the Transport interface class
+  /// to support the gridconnect protocol over serial
+  //
+
+  class SerialGC : public CanTransport
+  {
+  public:
+
+    bool begin();
+
+    bool available() override;
+    CANMessage getNextCanMessage() override;
+    bool sendCanMessage(CANMessage *msg) override;
+    void reset() override;
+
+    unsigned int receiveCounter() override { return receivedCount; }
+    unsigned int transmitCounter() override { return transmitCount; }
+    unsigned int receiveErrorCounter() override { return receiveErrorCount; }
+    unsigned int transmitErrorCounter() override { return transmitErrorCount; }
+    unsigned int errorStatus() override { return 0; }
+
+
+  private:
+
+    char rxBuffer[RXBUFFERSIZE]; // Define a byte array to store the incoming data
+    char txBuffer[RXBUFFERSIZE]; // Define a byte array to store the outgoing data
+    CANMessage rxCANMessage;
+
+    unsigned int receivedCount = 0;
+    unsigned int transmitCount = 0;
+    unsigned int receiveErrorCount = 0;
+    unsigned int transmitErrorCount = 0;
+
+    void debugCANMessage(CANMessage message);
+
+  };
+
+}

--- a/test/testAll.cpp
+++ b/test/testAll.cpp
@@ -17,6 +17,7 @@ void testEventConsumerService();
 void testEventTeachingService();
 void testConsumeOwnEventsService();
 void testLongMessageService();
+void testGridConnect();
 
 // Remaining services to implement
 //Bootloader (the CBUS PIC version) service #10
@@ -31,7 +32,8 @@ std::map<std::string, void (*)()> suites = {
         {"EventConsumerService", testEventConsumerService},
         {"EventTeachingService", testEventTeachingService},
         {"ConsumeOwnEventsService", testConsumeOwnEventsService},
-        {"LongMessageService", testLongMessageService}
+        {"LongMessageService", testLongMessageService},
+        {"GridConnect", testGridConnect}
 };
 
 int main(int argc, const char * const * argv)

--- a/test/testGridConnect.cpp
+++ b/test/testGridConnect.cpp
@@ -1,0 +1,232 @@
+
+#include <iostream>
+#include "TestTools.hpp"
+
+#include "GridConnect.h"
+
+void debugCANMessage(CANMessage message)
+  {
+    std::cout << std::endl << "CANMessage:";
+    std::cout << " id " << message.id << " length " << message.len;
+    std::cout << " data ";
+    for (int i=0; i <message.len; i++) {
+      if( i>0 ) std::cout << ",";
+      std::cout << message.data[i];
+    }
+    std::cout << std::endl;
+  }
+
+
+
+void testGridConnectEncode_StandardID(int ID, const char * expectedMessage, bool expectedResult){
+  test();
+  char msgBuffer[28]; 
+  CANMessage msg;
+  msg.ext = 0;
+  msg.len = 2;
+  msg.rtr = 0;
+  msg.id = ID;
+  msg.data[0] = 1;
+  msg.data[1] = 2;
+
+  bool result = VLCB::encodeGridConnect(msgBuffer, &msg);
+
+  assertEquals(expectedMessage, msgBuffer);
+  assertEquals(expectedResult, result);
+
+//  std::cout << "encoded message " << msgBuffer << std::endl;  
+}
+
+
+void testGridConnectEncode_ExtendedID(int ID, const char * expectedMessage, bool expectedResult){
+  test();
+  char msgBuffer[28]; 
+  CANMessage msg;
+  msg.ext = true;
+  msg.len = 2;
+  msg.rtr = 0;
+  msg.id = ID;
+  msg.data[0] = 1;
+  msg.data[1] = 2;
+
+  bool result = VLCB::encodeGridConnect(msgBuffer, &msg);
+
+  assertEquals(expectedMessage, msgBuffer);
+  assertEquals(expectedResult, result);
+
+//  std::cout << "encoded message " << msgBuffer << std::endl;  
+}
+
+
+void testGridConnectEncode_RTR(bool rtr, const char * expectedMessage, bool expectedResult){
+  test();
+  char msgBuffer[28]; 
+  CANMessage msg;
+  msg.ext = 0;
+  msg.len = 2;
+  msg.rtr = rtr;
+  msg.id = 0x7FF;
+  msg.data[0] = 1;
+  msg.data[1] = 2;
+
+  bool result = VLCB::encodeGridConnect(msgBuffer, &msg);
+
+  assertEquals(expectedMessage, msgBuffer);
+  assertEquals(expectedResult, result);
+
+//  std::cout << "encoded message " << msgBuffer << std::endl;  
+}
+
+void testGridConnectEncode_DATA(int len, const char * expectedMessage, bool expectedResult){
+  test();
+  char msgBuffer[30]; 
+  CANMessage msg;
+  msg.ext = false;
+  msg.len = len;
+  msg.rtr = false;
+  msg.id = 0x7FF;
+  for (int i = 0; i<8; i++){
+    msg.data[i] = i+1;
+  }
+
+  bool result = VLCB::encodeGridConnect(msgBuffer, &msg);
+
+  assertEquals(expectedMessage, msgBuffer);
+  assertEquals(expectedResult, result);
+
+  //std::cout << "encoded message " << msgBuffer << std::endl << std::endl;  
+}
+
+
+void testGridConnectDecode_ID(const char * inputMessage, bool expectedEXT, int expectedID, bool expectedResult)
+{
+  test();
+  CANMessage msg;
+  bool result = VLCB::decodeGridConnect(inputMessage, &msg);
+
+  assertEquals(expectedResult, result);
+  if (result)
+  { // only check ID if result is true (i.e. decode worked)
+    assertEquals(expectedEXT, msg.ext);
+    assertEquals(expectedID, msg.id);
+    //std::cout << "decoded ID " << msg.id << std::endl << std::endl;  
+  }
+}
+
+void testGridConnectDecode_RTR(const char * inputMessage, bool expectedRTR, bool expectedResult)
+{
+  test();
+  CANMessage msg;
+  bool result = VLCB::decodeGridConnect(inputMessage, &msg);
+
+  assertEquals(expectedResult, result);
+  if (result)
+  { // only check ID if result is true (i.e. decode worked)
+    assertEquals(expectedRTR, msg.rtr);
+  }
+}
+
+void testGridConnectDecode_DATA(const char * inputMessage, int expectedLEN, bool expectedResult)
+{
+  test();
+  CANMessage msg;
+  bool result = VLCB::decodeGridConnect(inputMessage, &msg);
+
+  assertEquals(expectedResult, result);
+  if (result)
+  { // only check ID if result is true (i.e. decode worked)
+    assertEquals(expectedLEN, msg.len);
+  }
+}
+
+void testGridConnect(void){
+
+  // test encoding standard ID - 11 bits, max id 0x7FF
+  testGridConnectEncode_StandardID(0x0, ":S0000N0102;", true);
+  testGridConnectEncode_StandardID(0x1, ":S0020N0102;", true);
+  testGridConnectEncode_StandardID(0x7FF, ":SFFE0N0102;", true);
+  testGridConnectEncode_StandardID(0x800, "", false);
+  testGridConnectEncode_StandardID(0xFFFF, "", false);
+
+  // test encoding extended ID - 29 bits, max Id 0x1FFFFFFF
+  // encoded with bits 18 to 28 shifted by 3
+  // so need to test around this gap
+  testGridConnectEncode_ExtendedID(0x0, ":X00000000N0102;", true);        // all bits zero
+  testGridConnectEncode_ExtendedID(0x1, ":X00000001N0102;", true);        // just bit 0 set
+  testGridConnectEncode_ExtendedID(0x20000, ":X00020000N0102;", true);    // bit 17 - before break in coding
+  testGridConnectEncode_ExtendedID(0x3FFFF, ":X0003FFFFN0102;", true);    // all up to bit 17 - 18 bits
+  testGridConnectEncode_ExtendedID(0x40000, ":X00200000N0102;", true);    // bit 18 - after break in coding
+  testGridConnectEncode_ExtendedID(0x1FFC0000, ":XFFE00000N0102;", true); // bits 18 to 28 - 11 bits
+  testGridConnectEncode_ExtendedID(0x1FFFFFFF, ":XFFE3FFFFN0102;", true); // all 29 bits set
+  testGridConnectEncode_ExtendedID(0x20000000, "", false);
+  testGridConnectEncode_ExtendedID(0xFFFFFFFF, "", false);
+
+  // test encoding RTR character (boolean, so no invalid value)
+  testGridConnectEncode_RTR(false, ":SFFE0N0102;", true);
+  testGridConnectEncode_RTR(true, ":SFFE0R0102;", true);
+
+  // test encoding data field, passing length parameter to the test
+  testGridConnectEncode_DATA(0, ":SFFE0N;", true);
+  testGridConnectEncode_DATA(1, ":SFFE0N01;", true);
+  testGridConnectEncode_DATA(8, ":SFFE0N0102030405060708;", true);
+  testGridConnectEncode_DATA(9, "", false);
+
+  // test decoding standard ID field, expectedEXT is false
+  testGridConnectDecode_ID(":S0000N;", false, 0x0, true);             // all bits clear
+  testGridConnectDecode_ID(":S0020N;", false, 0x1, true);             // bit 1 set
+  testGridConnectDecode_ID(":SFFE0N;", false, 0x7FF, true);           // bits 0 to 10 set
+  testGridConnectDecode_ID(":sFFE0N;", false, 0x7FF, false);          // bits 0 to 10 set - lower case
+  testGridConnectDecode_ID(":Sffe0N;", false, 0x7FF, false);          // bits 0 to 10 set - lower case
+  testGridConnectDecode_ID(":SQFE0N;", false, 0x0, false);            // non hex char in ID
+  testGridConnectDecode_ID(":SFFEQN;", false, 0x0, false);            // non hex char in ID
+
+  // test decoding extended ID field, expectedEXT is true
+  testGridConnectDecode_ID(":X00000000N;", true, 0x0, true);          // all bits clear
+  testGridConnectDecode_ID(":X00000001N;", true, 0x1, true);          // bit 1 set
+  testGridConnectDecode_ID(":X00020000N;", true, 0x20000, true);      // bit 17 set
+  testGridConnectDecode_ID(":X0003FFFFN;", true, 0x3FFFF, true);      // bits 0 to 17 set
+  testGridConnectDecode_ID(":X00200000N;", true, 0x40000, true);      // bit 18 set
+  testGridConnectDecode_ID(":XFFE00000N;", true, 0x1FFC0000, true);   // bits 18 to 28 set
+  testGridConnectDecode_ID(":XFFE3FFFFN;", true, 0x1FFFFFFF, true);   // all bits 0 to 28 set
+  testGridConnectDecode_ID(":xFFE3FFFFN;", true, 0x1FFFFFFF, false);  // all bits 0 to 28 set - lower case
+  testGridConnectDecode_ID(":Xffe3ffffN;", true, 0x1FFFFFFF, false);  // all bits 0 to 28 set - lower case
+  testGridConnectDecode_ID(":XFFFFFFFFN;", true, 0x1FFFFFFF, true);   // check it ignores unused bits
+  testGridConnectDecode_ID(":XQ0000000N;", true, 0x0, false);         // non hex char in ID
+  testGridConnectDecode_ID(":X0000000QN;", true, 0x0, false);         // non hex char in ID
+  
+  // test decode RTR - params are inoput msg, expected RTR, expected result from decode
+  testGridConnectDecode_RTR(":S0000N;", false, true);             // standard msg, RTR false
+  testGridConnectDecode_RTR(":S0000R;", true, true);              // standard msg, RTR true
+  testGridConnectDecode_RTR(":S0000n;", false, false);            // standard msg, lower case
+  testGridConnectDecode_RTR(":S0000r;", true, false);             // standard msg, lower case
+  testGridConnectDecode_RTR(":S0000Q;", true, false);             // standard msg, invalid char in RTR field
+  testGridConnectDecode_RTR(":X00000000N;", false, true);         // extended msg, RTR false
+  testGridConnectDecode_RTR(":X00000000R;", true, true);          // extended msg, RTR true
+  testGridConnectDecode_RTR(":X00000000n;", false, false);        // extended msg, lower case
+  testGridConnectDecode_RTR(":X00000000r;", true, false);         // extended msg, lower case
+  testGridConnectDecode_RTR(":X00000000Q;", true, false);         // extended msg, invalid char in RTR field
+
+  // test decode data field, standard message
+  testGridConnectDecode_DATA(":S0000N;", 0, true);                          // standard msg, zero data
+  testGridConnectDecode_DATA(":S0000N01;", 1, true);                        // standard msg, 1 data byte
+  testGridConnectDecode_DATA(":S0000N000102030405FEFF;", 8, true);          // standard msg, 8 data bytes
+  testGridConnectDecode_DATA(":S0000N000102030405feff;", 8, false);          // standard msg, lower case should fail
+  testGridConnectDecode_DATA(":S0000N0;", 1, false);                        // standard msg, wrong number of data chars
+  testGridConnectDecode_DATA(":S0000N000102030405FEF;", 8, false);          // standard msg, wrong number of data chars
+  testGridConnectDecode_DATA(":S0000N000102030405FEFF09;", 9, false);       // standard msg, too many data bytes
+  testGridConnectDecode_DATA(":S0000NQ00102030405FEFF;", 8, false);          // standard msg, invalid char in data
+  testGridConnectDecode_DATA(":S0000N000102030405FEFQ;", 8, false);          // standard msg, invalid char in data
+
+  // test decode data field, extended message
+  testGridConnectDecode_DATA(":X00000000N;", 0, true);                      // extended msg, zero data
+  testGridConnectDecode_DATA(":X00000000N01;", 1, true);                    // extended msg, 1 data byte
+  testGridConnectDecode_DATA(":X00000000N000102030405FEFF;", 8, true);      // extended msg, 8 data bytes
+  testGridConnectDecode_DATA(":X00000000N000102030405feff;", 8, false);     // extended msg, lower case should fail
+  testGridConnectDecode_DATA(":X00000000N0;", 1, false);                    // extended msg, wrong number of data chars
+  testGridConnectDecode_DATA(":X00000000N000102030405FEF;", 8, false);      // extended msg, wrong number of data chars
+  testGridConnectDecode_DATA(":X00000000N000102030405FEFF09;", 9, false);   // extended msg, too many data bytes
+  testGridConnectDecode_DATA(":X00000000NQ00102030405FEFF;", 8, false);     // extended msg, invalid char in data
+  testGridConnectDecode_DATA(":X00000000N000102030405FEFQ;", 8, false);     // extended msg, invalid char in data
+
+
+}


### PR DESCRIPTION
* Started to add SerialGC

* Started SerialGC receive

* SerialGC removed rxState

* SerialGC started encode CANMessage

* Started adding SeriaGC::encodeCANMessage

* more work on serialGC

* forced upper case on grisconnect receive

* SerialGC now working, compliance test has 112 passes, but 21 errors

* refactoring SrialGC

* more refactoring of SerialGC

* Added check for valid hex data

* removed debug from checkHexChars

* SerialGC - added shift for 11 bit ID

* Amended description of GridConnect in SerialGC.cpp

* Added counters & encoding/decoding for 29 bit ID's

* Added new file - GridConnect for encode/decode functions Added tests for encodeGridConnect - decode still to do

* Added tests for gridconnect decode

* Renamed gridconnect unit tests

* Changed SerialGC.cpp to use GridConnect.cpp

* added ctype.h to gridconnect.cpp

* Changes from reviews

* changes from reviews

* now use tolower()

* Test for lower case in Gridconnect string

* Removed unneccesary isaplha()

* added ctype.h to SerialGC.cpp

* revert testAll.cpp

* re-added GridConnect to testAll.cpp